### PR TITLE
Proposed fix for uninitialized constant Class::Formulae

### DIFF
--- a/livecheck/extend/formulary.rb
+++ b/livecheck/extend/formulary.rb
@@ -3,16 +3,24 @@ require_relative "formula"
 class Formulary
   class << self
     # extended to load the Livecheckable version of a formula
-    alias_method :orig_factory, :factory
-    def factory(ref, spec = :stable)
-      formula = orig_factory(ref, spec)
-      livecheckable_path = LIVECHECKABLES_PATH / formula.path.basename
+    def load_formula(name, path, contents, namespace)
+      mod = Module.new
+      const_set(namespace, mod)
+      mod.module_eval(contents, path)
 
+      livecheckable_path = LIVECHECKABLES_PATH / path.basename
       if File.exist?(livecheckable_path)
-        puts "Loading #{LIVECHECKABLES_PATH/ref}" if ARGV.debug?
-        Formulae.module_eval(livecheckable_path.read, livecheckable_path)
+        puts "Loading #{LIVECHECKABLES_PATH / path.basename}" if ARGV.debug?
+        mod.module_eval(livecheckable_path.read, livecheckable_path)
       end
-      formula
+
+      class_name = class_s(name)
+
+      begin
+        mod.const_get(class_name)
+      rescue NameError => e
+        raise FormulaUnavailableError, name, e.backtrace
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, I am receiving the following error when attempting to check for updated versions of provided formula `ant.rb`:
```
$ brew livecheck ant
Error: uninitialized constant Class::Formulae
/usr/local/Library/Taps/jeffreywildman/homebrew-livecheck/livecheck/extend/formulary.rb:13:in `factory'
/usr/local/Library/Homebrew/formulary.rb:352:in `find_with_priority'
/usr/local/Library/Homebrew/extend/ARGV.rb:20:in `block in formulae'
/usr/local/Library/Homebrew/extend/ARGV.rb:16:in `map'
/usr/local/Library/Homebrew/extend/ARGV.rb:16:in `formulae'
/usr/local/Library/Taps/jeffreywildman/homebrew-livecheck/cmd/brew-livecheck.rb:94:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/brew.rb:23:in `require?'
/usr/local/Library/brew.rb:93:in `<main>'
```

I am using a forked, but identical, tap of homebrew-livecheck.

I have managed to write a workaround by overriding Formulary's `load_formula` method instead of the `factory` method -- this allowed me to stack a second call to module_eval to include any livecheckables formula content. I don't know if this is a complete solution, but hope it contributes towards one.