### PR TITLE
Fix python.rb

### DIFF
--- a/Livecheckables/python.rb
+++ b/Livecheckables/python.rb
@@ -1,4 +1,4 @@
 class Python
   livecheck :url => "https://www.python.org/ftp/python",
-            :regex => %r{href="(2(?:\.\d)+)/"}
+            :regex => %r{href="(2(?:\.\d+)+)/"}
 end


### PR DESCRIPTION
Allow livechecking of python above 2.7.9