### PR TITLE
Add sub-command functionality

### DIFF
--- a/cmd/brew-livecheck.rb
+++ b/cmd/brew-livecheck.rb
@@ -94,7 +94,7 @@ if ARGV.flag?("--help")
   exit 0
 end
 
-require? "livecheck/commands/" + ARGV[0]
+require? "livecheck/commands/" + ARGV.named[0]
 
 formulae_to_check =
   case

--- a/cmd/brew-livecheck.rb
+++ b/cmd/brew-livecheck.rb
@@ -29,6 +29,15 @@ usage = <<-EOF.undent
   -d, --debug       show debugging info
 EOF
 
+# Taken directly from Homebrew
+def require?(path)
+  require path
+rescue LoadError => e
+  # HACK: ( because we should raise on syntax errors but
+  # not if the file doesn't exist. TODO make robust!
+  raise unless e.to_s.include? path
+end
+
 if (Pathname.new(File.expand_path("..", __FILE__)).basename).to_s == "bin"
   opoo <<-EOS.undent
     It seems you are using an old version of homebrew-livecheck.
@@ -85,7 +94,9 @@ if ARGV.flag?("--help")
   exit 0
 end
 
-formulae_to_check = 
+require? "livecheck/commands/" + ARGV[0]
+
+formulae_to_check =
   case
   when ARGV.flag?("--installed")
     Formula.installed

--- a/cmd/brew-livecheck.rb
+++ b/cmd/brew-livecheck.rb
@@ -94,7 +94,7 @@ if ARGV.flag?("--help")
   exit 0
 end
 
-require? "livecheck/commands/" + ARGV.named[0]
+require?("livecheck/commands/" + ARGV.named[0]) && exit
 
 formulae_to_check =
   case

--- a/livecheck/commands/cat.rb
+++ b/livecheck/commands/cat.rb
@@ -1,4 +1,3 @@
 # Ignores all formulae but first (this is by design)
 livecheckable_path = LIVECHECKABLES_PATH / "#{ARGV.named[1]}.rb"
 puts File.open(livecheckable_path).read
-exit 0

--- a/livecheck/commands/cat.rb
+++ b/livecheck/commands/cat.rb
@@ -1,0 +1,4 @@
+# Ignores all formulae but first (this is by design)
+livecheckable_path = LIVECHECKABLES_PATH / "#{ARGV[1]}.rb"
+puts File.open(livecheckable_path).read
+exit 0

--- a/livecheck/commands/cat.rb
+++ b/livecheck/commands/cat.rb
@@ -1,4 +1,4 @@
 # Ignores all formulae but first (this is by design)
-livecheckable_path = LIVECHECKABLES_PATH / "#{ARGV[1]}.rb"
+livecheckable_path = LIVECHECKABLES_PATH / "#{ARGV.named[1]}.rb"
 puts File.open(livecheckable_path).read
 exit 0


### PR DESCRIPTION
Dead simple sub-command implementation. Each sub-command is a script (in the sense of "no classes, no methods, no nothing") in livecheck/commands. It would definitely be more "correct" to do it with classes, so feel free to close this if you care about that kind of thing.