### PR TITLE
euristic: fix GitHubGitDownloadStrategy regression

### DIFF
--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -6,7 +6,7 @@ def version_euristic(urls, regex = nil)
     puts "Trying with url #{url}" if ARGV.debug?
     match_version_map = {}
     case
-    when DownloadStrategyDetector.detect(url) == GitDownloadStrategy
+    when DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
       puts "Possible git repo detected at #{url}" if ARGV.debug?
 
       git_tags(url, regex).each do |tag|


### PR DESCRIPTION
Fixes a regression caused by Homebrew/brew@1693ddb by checking for
inheritance from, rather than equality to, GitDownloadStrategy so that
the new subclass GitHubGitDownloadStrategy is handled correctly.

Hi @youtux!