### PR TITLE
Make Formulary a module

### DIFF
--- a/livecheck/extend/formulary.rb
+++ b/livecheck/extend/formulary.rb
@@ -1,6 +1,6 @@
 require_relative "formula"
 
-class Formulary
+module Formulary
   class << self
     # extended to load the Livecheckable version of a formula
     def load_formula(name, path, contents, namespace)


### PR DESCRIPTION
To match changes in https://github.com/Homebrew/brew/pull/2066,
extend the Formulary module, not class.

Deals with https://github.com/youtux/homebrew-livecheck/issues/13